### PR TITLE
Show IP with event_sensors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ drivers/**/.tmp_versions/
 
 user/**/*.o
 user/show_ip/show_ip
+user/event_sensors/event_sensors
 user/streaming_sensors/streaming_sensors
 
 # ModelSim temporary files

--- a/user/event_sensors/apds9301.h
+++ b/user/event_sensors/apds9301.h
@@ -20,6 +20,9 @@ public:
 protected:
     std::optional<APDS9301Data> doPoll() override;
     void doProcess(APDS9301Data const &data) override;
+
+private:
+    int mIP_octet;
 };
 
 #endif  // APDS9301_H

--- a/user/event_sensors/apds9301.h
+++ b/user/event_sensors/apds9301.h
@@ -3,15 +3,16 @@
 
 #include "sensors.h"
 
-
-struct APDS9301Data : public Serializable {
+struct APDS9301Data : public Serializable
+{
     std::string toJsonString() const override;
 
     uint64_t timeStamp;
     uint16_t value;
 };
 
-class APDS9301 : public StreamingSensor<APDS9301Data> {
+class APDS9301 : public StreamingSensor<APDS9301Data>
+{
 public:
     using StreamingSensor::StreamingSensor;
 
@@ -22,7 +23,7 @@ protected:
     void doProcess(APDS9301Data const &data) override;
 
 private:
-    int mIP_octet;
+    int mIP_octet = 0;
 };
 
-#endif  // APDS9301_H
+#endif // APDS9301_H

--- a/user/event_sensors/get_ip.cpp
+++ b/user/event_sensors/get_ip.cpp
@@ -1,0 +1,169 @@
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include <cstdio>
+#include <cstdint>
+
+#include <iostream>
+#include <string>
+#include <thread>
+#include <chrono>
+#include <memory>
+
+using namespace std::literals::chrono_literals;
+
+static const std::string CHARACTER_DEVICE = "/dev/sevensegment";
+static const int SEGMENT_COUNT = 6;
+
+struct IPv4Address
+{
+  uint8_t segments[4];
+};
+
+int writeToCDev(char chars[], uint8_t brightness)
+{
+
+  // prepare input values
+  uint8_t values[SEGMENT_COUNT];
+  uint8_t combinedEnabled = 0;
+
+  for (int i = 0; i < SEGMENT_COUNT; ++i)
+  {
+    bool isValidChar = (chars[i] >= '0' && chars[i] <= '9');
+    combinedEnabled |= (((int)isValidChar) & 1) << (SEGMENT_COUNT - i - 1);
+
+    if (isValidChar)
+    {
+      values[i] = chars[i];
+    }
+    else
+    {
+      values[i] = '0';
+    }
+
+    // Convert to binary for driver
+    values[i] -= '0';
+  }
+
+  // open character device
+  auto fd = fopen(CHARACTER_DEVICE.c_str(), "wb");
+  if (!fd)
+  {
+    std::cerr << "Failed to open character device '" << CHARACTER_DEVICE << "'" << std::endl;
+    return -1;
+  }
+
+  // write display values
+  for (int i = 0; i < SEGMENT_COUNT; ++i)
+  {
+    if (fputc(values[i], fd) == EOF)
+    {
+      std::cerr << "Failed to write character (index " << i << ")" << std::endl;
+      return -1;
+    }
+  }
+
+  // write brightness level
+  if (fputc(brightness, fd) == EOF)
+  {
+    std::cerr << "Failed to write brightness level" << std::endl;
+    return -1;
+  }
+
+  // write enable bits
+  if (fputc(combinedEnabled, fd) == EOF)
+  {
+    std::cerr << "Failed to write enable bits" << std::endl;
+    return -1;
+  }
+
+  (void)fclose(fd);
+
+  return 0;
+}
+
+uint8_t getBrightness()
+{
+  uint8_t data[SEGMENT_COUNT + 2] = {0}; // +2 for brightness and enable byte
+
+  // open character device
+  auto fd = fopen(CHARACTER_DEVICE.c_str(), "rb");
+  if (!fd)
+  {
+    std::cerr << "Failed to open character device '" << CHARACTER_DEVICE << "'" << std::endl;
+    return -1;
+  }
+
+  memcpy(data, fd, sizeof(data));
+
+  (void)fclose(fd);
+
+  // Return the byte that represents the brightness value.
+  // (see driver file 'sevensegment.c')
+  return data[SEGMENT_COUNT];
+}
+
+IPv4Address getIP()
+{
+  // drop 127.0.0.1
+  static const uint32_t LOCAL_IP = 16777343;
+  IPv4Address result;
+
+  struct ifaddrs *ifAddrStruct = NULL;
+  getifaddrs(&ifAddrStruct);
+
+  for (auto ifa = ifAddrStruct; ifa != NULL; ifa = ifa->ifa_next)
+  {
+    if (!ifa->ifa_addr)
+    {
+      continue;
+    }
+
+    if (ifa->ifa_addr->sa_family == AF_INET)
+    {
+      auto ip = ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr.s_addr;
+      if (ip == LOCAL_IP)
+      {
+        continue;
+      }
+
+      // use the first non-local IP
+      for (int i = 0; i < 4; ++i)
+      {
+        result.segments[i] = static_cast<uint8_t>((ip >> (i * 8)) & 0xff);
+      }
+      break;
+    }
+  }
+
+  if (ifAddrStruct)
+  {
+    freeifaddrs(ifAddrStruct);
+  }
+
+  return result;
+}
+
+void show_ip()
+{
+
+  auto ip = getIP();
+
+  while (1)
+  {
+    for (int i = 0; i < 4; ++i)
+    {
+      char chars[7] = {0};
+      auto s = ip.segments[i];
+
+      snprintf(chars, 6, "%d", s);
+
+      uint8_t brightness = getBrightness();
+
+      (void)writeToCDev(chars, brightness);
+
+      std::this_thread::sleep_for(1000ms);
+    }
+  }
+}

--- a/user/event_sensors/get_ip.cpp
+++ b/user/event_sensors/get_ip.cpp
@@ -4,12 +4,12 @@
 
 #include <cstdio>
 #include <cstdint>
+#include <cstring>
 
 #include <iostream>
 #include <string>
 #include <thread>
 #include <chrono>
-#include <memory>
 
 using namespace std::literals::chrono_literals;
 
@@ -160,10 +160,11 @@ void show_ip()
       snprintf(chars, 6, "%d", s);
 
       uint8_t brightness = getBrightness();
+      std::cout << "Brightness: " << brightness << std::endl;
 
       (void)writeToCDev(chars, brightness);
 
-      std::this_thread::sleep_for(1000ms);
+      std::this_thread::sleep_for(500ms);
     }
   }
 }

--- a/user/event_sensors/get_ip.cpp
+++ b/user/event_sensors/get_ip.cpp
@@ -11,100 +11,16 @@
 #include <thread>
 #include <chrono>
 
-using namespace std::literals::chrono_literals;
+#include "get_ip.h"
 
-static const std::string CHARACTER_DEVICE = "/dev/sevensegment";
-static const int SEGMENT_COUNT = 6;
+using namespace std::literals::chrono_literals;
 
 struct IPv4Address
 {
   uint8_t segments[4];
 };
 
-int writeToCDev(char chars[], uint8_t brightness)
-{
-
-  // prepare input values
-  uint8_t values[SEGMENT_COUNT];
-  uint8_t combinedEnabled = 0;
-
-  for (int i = 0; i < SEGMENT_COUNT; ++i)
-  {
-    bool isValidChar = (chars[i] >= '0' && chars[i] <= '9');
-    combinedEnabled |= (((int)isValidChar) & 1) << (SEGMENT_COUNT - i - 1);
-
-    if (isValidChar)
-    {
-      values[i] = chars[i];
-    }
-    else
-    {
-      values[i] = '0';
-    }
-
-    // Convert to binary for driver
-    values[i] -= '0';
-  }
-
-  // open character device
-  auto fd = fopen(CHARACTER_DEVICE.c_str(), "wb");
-  if (!fd)
-  {
-    std::cerr << "Failed to open character device '" << CHARACTER_DEVICE << "'" << std::endl;
-    return -1;
-  }
-
-  // write display values
-  for (int i = 0; i < SEGMENT_COUNT; ++i)
-  {
-    if (fputc(values[i], fd) == EOF)
-    {
-      std::cerr << "Failed to write character (index " << i << ")" << std::endl;
-      return -1;
-    }
-  }
-
-  // write brightness level
-  if (fputc(brightness, fd) == EOF)
-  {
-    std::cerr << "Failed to write brightness level" << std::endl;
-    return -1;
-  }
-
-  // write enable bits
-  if (fputc(combinedEnabled, fd) == EOF)
-  {
-    std::cerr << "Failed to write enable bits" << std::endl;
-    return -1;
-  }
-
-  (void)fclose(fd);
-
-  return 0;
-}
-
-uint8_t getBrightness()
-{
-  uint8_t data[SEGMENT_COUNT + 2] = {0}; // +2 for brightness and enable byte
-
-  // open character device
-  auto fd = fopen(CHARACTER_DEVICE.c_str(), "rb");
-  if (!fd)
-  {
-    std::cerr << "Failed to open character device '" << CHARACTER_DEVICE << "'" << std::endl;
-    return -1;
-  }
-
-  memcpy(data, fd, sizeof(data));
-
-  (void)fclose(fd);
-
-  // Return the byte that represents the brightness value.
-  // (see driver file 'sevensegment.c')
-  return data[SEGMENT_COUNT];
-}
-
-IPv4Address getIP()
+IPv4Address getIPfromSystem()
 {
   // drop 127.0.0.1
   static const uint32_t LOCAL_IP = 16777343;
@@ -145,26 +61,29 @@ IPv4Address getIP()
   return result;
 }
 
-void show_ip()
+getIPdata_t *get_ip(int hex_index)
 {
+  auto ip = getIPfromSystem();
 
-  auto ip = getIP();
+  char chars[7] = {0};
+  auto s = ip.segments[hex_index];
+  snprintf(chars, 6, "%d", s);
 
-  while (1)
+  static getIPdata_t data = {0};
+
+  for (int i = 0; i < SEGMENT_COUNT; ++i)
   {
-    for (int i = 0; i < 4; ++i)
+    bool isValidChar = (chars[i] >= '0' && chars[i] <= '9');
+    data.hex_enable |= (((int)isValidChar) & 1) << (SEGMENT_COUNT - i - 1);
+
+    if (isValidChar)
     {
-      char chars[7] = {0};
-      auto s = ip.segments[i];
-
-      snprintf(chars, 6, "%d", s);
-
-      uint8_t brightness = getBrightness();
-      std::cout << "Brightness: " << brightness << std::endl;
-
-      (void)writeToCDev(chars, brightness);
-
-      std::this_thread::sleep_for(500ms);
+      data.hex_values[i] = chars[i];
+    }
+    else
+    {
+      data.hex_values[i] = '0';
     }
   }
+  return &data;
 }

--- a/user/event_sensors/get_ip.h
+++ b/user/event_sensors/get_ip.h
@@ -1,6 +1,15 @@
 #ifndef GET_IP_H
 #define GET_IP_H
 
-void show_ip();
+static const std::string CHARACTER_DEVICE = "/dev/sevensegment";
+static const int SEGMENT_COUNT = 6;
+
+struct getIPdata_t
+{
+  uint8_t hex_values[SEGMENT_COUNT];
+  uint8_t hex_enable;
+};
+
+getIPdata_t *get_ip(int hex_index);
 
 #endif // GET_IP_H

--- a/user/event_sensors/get_ip.h
+++ b/user/event_sensors/get_ip.h
@@ -1,0 +1,6 @@
+#ifndef GET_IP_H
+#define GET_IP_H
+
+void show_ip();
+
+#endif // GET_IP_H

--- a/user/event_sensors/main.cpp
+++ b/user/event_sensors/main.cpp
@@ -22,6 +22,7 @@
 
 using namespace std::literals::chrono_literals;
 
+
 void compressMemory(void *in_data, size_t in_data_size, std::vector<uint8_t> &out_data)
 {
     std::vector<uint8_t> buffer;
@@ -219,7 +220,6 @@ int main(int argc, char *argv[])
     sensorThreads.emplace_back(std::bind(&HDC1000::startPolling, &hdc1000));
     sensorThreads.emplace_back(std::bind(&MPU9250::startPolling, &mpu9250));
     sensorThreads.emplace_back(std::bind(&APDS9301::startPolling, &apds9301));
-    sensorThreads.emplace_back(std::thread(show_ip));
 
     //
     // Every second publish all available sensor data at once

--- a/user/event_sensors/main.cpp
+++ b/user/event_sensors/main.cpp
@@ -1,6 +1,4 @@
 #include <mqtt/client.h>
-#include <mqtt/ssl_options.h>
-#include <mqtt/connect_options.h>
 #include <zlib.h>
 
 #include <algorithm>
@@ -145,7 +143,7 @@ std::optional<std::string> getTrustStore(const std::string &certPath)
 
 
 int main(int argc, char *argv[]) {
-    static const std::string SERVER_URI = "ssl://193.170.192.224:8883";
+    static const std::string SERVER_URI = "193.170.192.224:1883";
     static const std::string CLIENT_ID  = "event_sensors";
     static const int DEFAULT_THRESHOLD = 12000;
 
@@ -193,18 +191,7 @@ int main(int argc, char *argv[]) {
     // Setup MQTT client
     //
     mqtt::client client(SERVER_URI, CLIENT_ID);
-    mqtt::ssl_options sslOptions;
-    auto trustStoreOpt = getTrustStore("ca.crt");
-    if (!trustStoreOpt.has_value()) {
-        return -1;
-    }
-    sslOptions.set_trust_store(trustStoreOpt.value());
-
-    mqtt::connect_options options;
-    options.set_ssl(sslOptions);
-
-    client.connect(options);
-
+    client.connect();
 
     //
     // Setup sensors

--- a/user/event_sensors/main.cpp
+++ b/user/event_sensors/main.cpp
@@ -21,7 +21,6 @@
 
 using namespace std::literals::chrono_literals;
 
-
 void compressMemory(void *in_data, size_t in_data_size, std::vector<uint8_t> &out_data)
 {
     std::vector<uint8_t> buffer;
@@ -81,17 +80,20 @@ void publishData(const std::vector<DATA> &data, const std::string &topic, mqtt::
     // how many burst packets need to be sent?
     int bursts = std::ceil(1.0 * data.size() / MAX_PACKETS_PER_BURST);
 
-    for (int b = 0; b < bursts; b++) {
+    for (int b = 0; b < bursts; b++)
+    {
         // the size of the current burst packet
-        int size = std::min(MAX_PACKETS_PER_BURST, (int) data.size() - b * MAX_PACKETS_PER_BURST);
+        int size = std::min(MAX_PACKETS_PER_BURST, (int)data.size() - b * MAX_PACKETS_PER_BURST);
 
         msg.str("");
         msg << "[";
 
         bool first = true;
-        for (int i = 0; i < size; i++) {
+        for (int i = 0; i < size; i++)
+        {
             auto &v = data[b * MAX_PACKETS_PER_BURST + i];
-            if (!first) {
+            if (!first)
+            {
                 msg << ",";
             }
             first = false;
@@ -108,8 +110,9 @@ void publishData(const std::vector<DATA> &data, const std::string &topic, mqtt::
     }
 }
 
-template<class SENSOR>
-void publishSensorData(SENSOR &sensor, mqtt::client &client) {
+template <class SENSOR>
+void publishSensorData(SENSOR &sensor, mqtt::client &client)
+{
     auto pollingData = sensor.getQueue();
     auto eventData = sensor.getEventQueue();
 
@@ -127,12 +130,14 @@ std::optional<std::string> getTrustStore(const std::string &certPath)
     static const std::string FALLBACK_CERT = "/etc/SmartSystemsLab/ca.crt";
 
     std::ifstream f(certPath);
-    if (f) {
+    if (f)
+    {
         return certPath;
     }
 
     f.open(FALLBACK_CERT);
-    if (f) {
+    if (f)
+    {
         std::cout << "Using fallback certificate" << std::endl;
         return FALLBACK_CERT;
     }
@@ -141,10 +146,10 @@ std::optional<std::string> getTrustStore(const std::string &certPath)
     return std::nullopt;
 }
 
-
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[])
+{
     static const std::string SERVER_URI = "193.170.192.224:1883";
-    static const std::string CLIENT_ID  = "event_sensors";
+    static const std::string CLIENT_ID = "event_sensors";
     static const int DEFAULT_THRESHOLD = 12000;
 
     //
@@ -152,23 +157,29 @@ int main(int argc, char *argv[]) {
     //
     int threshold = DEFAULT_THRESHOLD;
 
-    if (argc > 2) {
+    if (argc > 2)
+    {
         std::cerr << "Usage: " << argv[0] << " [<event_threshold>]" << std::endl;
         return -1;
-    } else if (argc == 2) {
-        try {
+    }
+    else if (argc == 2)
+    {
+        try
+        {
             size_t idx = 0;
             threshold = std::stoi(argv[1], &idx);
 
-            if (idx < strlen(argv[1])) {
+            if (idx < strlen(argv[1]))
+            {
                 throw std::invalid_argument(argv[1]);
             }
-        } catch (const std::invalid_argument &ex) {
+        }
+        catch (const std::invalid_argument &ex)
+        {
             std::cerr << "Argument '" << argv[1] << "' cannot be parsed as an integer" << std::endl;
             return -1;
         }
     }
-
 
     //
     // Check operation mode
@@ -176,16 +187,18 @@ int main(int argc, char *argv[]) {
 #ifndef NO_SENSORS
     std::cout << "Operation mode: actual sensors" << std::endl;
 
-    try {
+    try
+    {
         initFPGA("event_sensors");
-    } catch (const std::string &s) {
+    }
+    catch (const std::string &s)
+    {
         std::cerr << "Failed to initialize FPGA: " << s << std::endl;
         return -1;
     }
 #else
     std::cout << "Operation mode: dummy data" << std::endl;
 #endif
-
 
     //
     // Setup MQTT client
@@ -206,12 +219,12 @@ int main(int argc, char *argv[]) {
     sensorThreads.emplace_back(std::bind(&MPU9250::startPolling, &mpu9250));
     sensorThreads.emplace_back(std::bind(&APDS9301::startPolling, &apds9301));
 
-
     //
     // Every second publish all available sensor data at once
     //
     auto iterationEnd = std::chrono::high_resolution_clock::now();
-    while (true) {
+    while (true)
+    {
         iterationEnd += std::chrono::milliseconds(1000);
 
         // std::cout << "HDC1000: ";
@@ -231,7 +244,8 @@ int main(int argc, char *argv[]) {
     mpu9250.stop();
     apds9301.stop();
 
-    for (auto &&t: sensorThreads) {
+    for (auto &&t : sensorThreads)
+    {
         t.join();
     }
     return 0;

--- a/user/event_sensors/main.cpp
+++ b/user/event_sensors/main.cpp
@@ -18,6 +18,7 @@
 #include "hdc1000.h"
 #include "mpu9250.h"
 #include "sensors.h"
+#include "get_ip.h"
 
 using namespace std::literals::chrono_literals;
 
@@ -218,6 +219,7 @@ int main(int argc, char *argv[])
     sensorThreads.emplace_back(std::bind(&HDC1000::startPolling, &hdc1000));
     sensorThreads.emplace_back(std::bind(&MPU9250::startPolling, &mpu9250));
     sensorThreads.emplace_back(std::bind(&APDS9301::startPolling, &apds9301));
+    sensorThreads.emplace_back(std::thread(show_ip));
 
     //
     // Every second publish all available sensor data at once


### PR DESCRIPTION
Currently, `event_sensors` only displays "000000" with the measured brightness.

Display the IP address instead.